### PR TITLE
Don't exit in `Rgot::Cli#run`

### DIFF
--- a/bin/rgot
+++ b/bin/rgot
@@ -1,4 +1,4 @@
 #! /usr/bin/env ruby
 require 'rgot/cli'
 
-Rgot::Cli.new(ARGV).run
+exit Rgot::Cli.new(ARGV).run

--- a/lib/rgot/cli.rb
+++ b/lib/rgot/cli.rb
@@ -148,7 +148,7 @@ module Rgot
         end
       end
 
-      exit code
+      code
     end
   end
 end


### PR DESCRIPTION
Fix the problem that subsequent tasks cannot be executed when calling `Rgot::Cli#run` from rake task.